### PR TITLE
Add R6 to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     testthat
 Suggests:
     knitr,
-    rmarkdown (>= 1.0)
+    rmarkdown (>= 1.0),
+    R6
 License: MIT + file LICENSE
 Collate:
     'expectations.R'


### PR DESCRIPTION
R6 is used in the tests, so it needs to be included in the Suggests for
the package.

It should also be noted that the package is currently ORPHANED on CRAN, with this same change applied. ORPHANED packages can be claimed by any maintainer, so if you would like to continue maintainership it would be best to apply this change and prepare a new CRAN release.

If you do _not_ want to continue to be the maintainer please let us know here and I or one of my colleagues would be happy to take over maintainership. We use mockery in a number of our packages so would like it to remain on CRAN in an unorphaned state.